### PR TITLE
Update analysis_ui_utils.py

### DIFF
--- a/mimic/scripts/analysis/analysis_ui_utils.py
+++ b/mimic/scripts/analysis/analysis_ui_utils.py
@@ -283,7 +283,7 @@ class DataControlWidget(QtWidgets.QWidget):
         main_layout.addWidget(toggle_widget)
 
         # Add a spacing character
-        main_layout.addWidget(QtWidgets.QLabel(unichr(0x2022)), alignment=4)
+        main_layout.addWidget(QtWidgets.QLabel(unichr(0x2022)), alignment=QtCore.Qt.AlignCenter)
 
         # Create and add "isolate" toggle
         isolate_widget = self.__build_isolate_toggle_widget()


### PR DESCRIPTION
line 286 - for some odd reason, Maya 2020 doesn't like the "alignment=4" syntax. Tested using Mac and Windows and it's compatible with Maya 2019