### PR TITLE
Accurately report time index when saving 'Keyframes Only'

### DIFF
--- a/mimic/scripts/analysis/analysis_utils.py
+++ b/mimic/scripts/analysis/analysis_utils.py
@@ -258,7 +258,7 @@ def _generate_derivative_dicts(command_dicts, order):
 
                 displacement = current_axis - previous_axis
                 # Do we need to compute displacement_time between every frame? Does this change?
-                displacement_time = current_command['Time Index'] - previous_command['Time Index']
+                displacement_time = current_command[postproc.TIME_INDEX] - previous_command[postproc.TIME_INDEX]
                 derivative = displacement / displacement_time
                 current_axes_derivative[axis_index] = derivative
 
@@ -295,7 +295,7 @@ def _generate_derivative_dicts(command_dicts, order):
                 for derivative_index, current_axis in enumerate(current_axes):
                     previous_axis = previous_axes[derivative_index]
                     displacement = current_axis - previous_axis
-                    displacement_time = current_command['Time Index'] - previous_command['Time Index']
+                    displacement_time = current_command[postproc.TIME_INDEX] - previous_command[postproc.TIME_INDEX]
                     derivative = displacement / displacement_time
                     current_axes_derivative[derivative_index] = derivative
 

--- a/mimic/scripts/postproc/GENERAL/CSV/comma_separated_vals.py
+++ b/mimic/scripts/postproc/GENERAL/CSV/comma_separated_vals.py
@@ -72,9 +72,8 @@ TEMPLATES = {
 
 # COMMANDS
 RECORDS_COMMAND = 'RECORDS_COMMAND'
-_time_index = 'time_index'
 _records_command_fields = [
-    _time_index,
+    postproc.TIME_INDEX,
     postproc.AXES,
     postproc.EXTERNAL_AXES,
     postproc.DIGITAL_OUTPUT,
@@ -149,11 +148,7 @@ class SimpleCSVProcessor(postproc.PostProcessor):
         # Try to get a RecordCommand
         params = []
         for field in _records_command_fields:
-            if field == _time_index:  # Get the timestamp itself
-                time_index = params_dict['Time Index']
-                param = time_index
-            else:
-                param = params_dict[field] if field in params_dict else None
+            param = params_dict[field] if field in params_dict else None
             params.append(param)
         if params.count(None) != len(params):
             # params.insert(0, self.time_index)  # Include current time-index

--- a/mimic/scripts/postproc/GENERAL/TSV/tab_separated_vals.py
+++ b/mimic/scripts/postproc/GENERAL/TSV/tab_separated_vals.py
@@ -72,9 +72,8 @@ TEMPLATES = {
 
 # COMMANDS
 RECORDS_COMMAND = 'RECORDS_COMMAND'
-_time_index = 'time_index'
 _records_command_fields = [
-    _time_index,
+    postproc.TIME_INDEX,
     postproc.AXES,
     postproc.EXTERNAL_AXES,
     postproc.DIGITAL_OUTPUT,
@@ -149,11 +148,7 @@ class SimpleTSVProcessor(postproc.PostProcessor):
         # Try to get a RecordCommand
         params = []
         for field in _records_command_fields:
-            if field == _time_index:  # Get the timestamp itself
-                time_index = params_dict['Time Index']
-                param = time_index
-            else:
-                param = params_dict[field] if field in params_dict else None
+            param = params_dict[field] if field in params_dict else None
             params.append(param)
         if params.count(None) != len(params):
             # params.insert(0, self.time_index)  # Include current time-index

--- a/mimic/scripts/postproc/KUKA/EntertainTech/entertaintech.py
+++ b/mimic/scripts/postproc/KUKA/EntertainTech/entertaintech.py
@@ -72,9 +72,8 @@ TEMPLATES = {
 
 # COMMANDS
 RECORDS_COMMAND = 'RECORDS_COMMAND'
-_time_index = 'time_index'
 _records_command_fields = [
-    _time_index,
+    postproc.TIME_INDEX,
     postproc.AXES,
     postproc.EXTERNAL_AXES,
     postproc.DIGITAL_OUTPUT,
@@ -154,11 +153,7 @@ class SimpleEntertainTechProcessor(postproc.PostProcessor):
         # Try to get a RecordCommand
         params = []
         for field in _records_command_fields:
-            if field == _time_index:  # Get the timestamp itself
-                time_index = params_dict['Time Index']
-                param = time_index
-            else:
-                param = params_dict[field] if field in params_dict else None
+            param = params_dict[field] if field in params_dict else None
             params.append(param)
         if params.count(None) != len(params):
             # params.insert(0, self.time_index)  # Include current time-index

--- a/mimic/scripts/postproc/postproc.py
+++ b/mimic/scripts/postproc/postproc.py
@@ -43,6 +43,8 @@ __identifier = 'identifier'
 __value = 'value'
 
 # STRUCTURES
+TIME_INDEX = 'time_index'
+
 AXES = 'axes'
 Axes = namedtuple(
     AXES, [


### PR DESCRIPTION
The previous method of calculating 'Time Index' was sufficient for time interval exports, but Keyframe Only exports were known to have incorrect values in that field.
By calculating the time from the starting frame, current frame, and animation framerate, we can give an accurate value for the Time Index in both time interval and keyframe only modes.

Accurate timestamps for the keyframes lets us correlate a full export and a keyframe only export and would allow controllers to do things like start motion from any Keyframe. It could also allow Mimic to import previously saved keyframes into the current session (if that is ever desired).