### PR TITLE
allow multiple commands to be generated per frame to permit concurrent motion / IO export

### DIFF
--- a/mimic3/scripts/postproc/ABB/RAPID/rapid.py
+++ b/mimic3/scripts/postproc/ABB/RAPID/rapid.py
@@ -256,26 +256,33 @@ class SimpleRAPIDProcessor(postproc.PostProcessor):
         For this processor:
         Can create a MotionCommand namedTuple from optional input parameters.
         Can create a IOCommand namedTuple from optional input parameters.
+        Returns a list of commands to allow possibly mutliple commands on separate
+        lines to be exported per frame.
 
         :param params_dict: Dictionary of namedtuple containing all command
         parameters (i.e. Axes, ExternalAxes, etc).
         :return:
         """
+        
+        commands = []
+
         # Try to get a MotionCommand
         params = []
         for field in _motion_command_fields:
             param = params_dict[field] if field in params_dict else None
             params.append(param)
         if params.count(None) != len(params):
-            return MotionCommand(*params)
-        else:
-            # Try to get an IO command
-            params = []
-            for field in _io_command_fields:
-                param = params_dict[field] if field in params_dict else None
-                params.append(param)
-            if params.count(None) != len(params):
-                return IOCommand(*params)
+            commands.append(MotionCommand(*params))
+        
+        # Try to get an IO command
+        params = []
+        for field in _io_command_fields:
+            param = params_dict[field] if field in params_dict else None
+            params.append(param)
+        if params.count(None) != len(params):
+            commands.append(IOCommand(*params))
+        
+        return commands
 
     @staticmethod
     def _set_supported_options():

--- a/mimic3/scripts/postproc/GENERAL/CSV/comma_separated_vals.py
+++ b/mimic3/scripts/postproc/GENERAL/CSV/comma_separated_vals.py
@@ -139,7 +139,10 @@ class SimpleCSVProcessor(postproc.PostProcessor):
         params flexibly and as needed.
 
         For this processor:
-        Can create a RecordsCommand namedTuple from optional input parameters.
+        Can create a MotionCommand namedTuple from optional input parameters.
+        Can create a IOCommand namedTuple from optional input parameters.
+        Returns a list of commands to allow possibly mutliple commands on separate
+        lines to be exported per frame.
 
         :param params_dict: Dictionary of namedtuple containing all command
         parameters (i.e. Axes, ExternalAxes, etc).
@@ -153,7 +156,7 @@ class SimpleCSVProcessor(postproc.PostProcessor):
         if params.count(None) != len(params):
             # params.insert(0, self.time_index)  # Include current time-index
             # self.time_index += self.time_step  # Increment to next time-index
-            return RecordsCommand(*params)
+            return [RecordsCommand(*params)]
 
     @staticmethod
     def _set_supported_options():

--- a/mimic3/scripts/postproc/KUKA/EntertainTech/entertaintech.py
+++ b/mimic3/scripts/postproc/KUKA/EntertainTech/entertaintech.py
@@ -144,7 +144,10 @@ class SimpleEntertainTechProcessor(postproc.PostProcessor):
         params flexibly and as needed.
 
         For this processor:
-        Can create a RecordsCommand namedTuple from optional input parameters.
+        Can create a MotionCommand namedTuple from optional input parameters.
+        Can create a IOCommand namedTuple from optional input parameters.
+        Returns a list of commands to allow possibly mutliple commands on separate
+        lines to be exported per frame.
 
         :param params_dict: Dictionary of namedtuple containing all command
         parameters (i.e. Axes, ExternalAxes, etc).
@@ -158,7 +161,7 @@ class SimpleEntertainTechProcessor(postproc.PostProcessor):
         if params.count(None) != len(params):
             # params.insert(0, self.time_index)  # Include current time-index
             # self.time_index += self.time_step  # Increment to next time-index
-            return RecordsCommand(*params)
+            return [RecordsCommand(*params)]
 
     @staticmethod
     def _set_supported_options():

--- a/mimic3/scripts/postproc/KUKA/KRL/krl.py
+++ b/mimic3/scripts/postproc/KUKA/KRL/krl.py
@@ -304,26 +304,33 @@ class SimpleKRLProcessor(postproc.PostProcessor):
         For this processor:
         Can create a MotionCommand namedTuple from optional input parameters.
         Can create a IOCommand namedTuple from optional input parameters.
+        Returns a list of commands to allow possibly mutliple commands on separate
+        lines to be exported per frame.
 
         :param params_dict: Dictionary of namedtuple containing all command
         parameters (i.e. Axes, ExternalAxes, etc).
         :return:
         """
+        
+        commands = []
+
         # Try to get a MotionCommand
         params = []
         for field in _motion_command_fields:
             param = params_dict[field] if field in params_dict else None
             params.append(param)
         if params.count(None) != len(params):
-            return MotionCommand(*params)
-        else:
-            # Try to get an IO command
-            params = []
-            for field in _io_command_fields:
-                param = params_dict[field] if field in params_dict else None
-                params.append(param)
-            if params.count(None) != len(params):
-                return IOCommand(*params)
+            commands.append(MotionCommand(*params))
+        
+        # Try to get an IO command
+        params = []
+        for field in _io_command_fields:
+            param = params_dict[field] if field in params_dict else None
+            params.append(param)
+        if params.count(None) != len(params):
+            commands.append(IOCommand(*params))
+        
+        return commands
 
     @staticmethod
     def _set_supported_options():

--- a/mimic3/scripts/postproc/Staubli/VAL3/val3.py
+++ b/mimic3/scripts/postproc/Staubli/VAL3/val3.py
@@ -302,26 +302,33 @@ class SimpleVAL3Processor(postproc.PostProcessor):
         For this processor:
         Can create a MotionCommand namedTuple from optional input parameters.
         Can create a IOCommand namedTuple from optional input parameters.
+        Returns a list of commands to allow possibly mutliple commands on separate
+        lines to be exported per frame.
 
         :param params_dict: Dictionary of namedtuple containing all command
         parameters (i.e. Axes, ExternalAxes, etc).
         :return:
         """
+        
+        commands = []
+
         # Try to get a MotionCommand
         params = []
         for field in _motion_command_fields:
             param = params_dict[field] if field in params_dict else None
             params.append(param)
         if params.count(None) != len(params):
-            return MotionCommand(*params)
-        else:
-            # Try to get an IO command
-            params = []
-            for field in _io_command_fields:
-                param = params_dict[field] if field in params_dict else None
-                params.append(param)
-            if params.count(None) != len(params):
-                return IOCommand(*params)
+            commands.append(MotionCommand(*params))
+        
+        # Try to get an IO command
+        params = []
+        for field in _io_command_fields:
+            param = params_dict[field] if field in params_dict else None
+            params.append(param)
+        if params.count(None) != len(params):
+            commands.append(IOCommand(*params))
+        
+        return commands
 
     @staticmethod
     def _set_supported_options():

--- a/mimic3/scripts/postproc/postproc.py
+++ b/mimic3/scripts/postproc/postproc.py
@@ -329,8 +329,8 @@ class PostProcessor(object):
         """
         commands = []
         for params_dict in params_dicts:
-            command = self._format_command(params_dict)
-            commands.append(command)
+            command_list = self._format_command(params_dict)
+            commands.extend(command_list)
         return commands
 
     def set_program_directory(self, directory):


### PR DESCRIPTION
`_format_command` subclass in post-processors returns a single namedTuple. This makes it impossible to generate separate commands for motion and IO per frame.

This PR changes the return type of `_format_command` to a list, and changes `format_commands` to extend instead of append to the `commands` list. Consequently all post-processors have been updated to return a list of namedTuple.

Tested all post-processors and seems to work all fine. Most processors dont currently include IO export capabilites but this makes it possible to add easily.