### PR TITLE
when using option "Sample keyframes only", grab all frames with either IK or FK keyframes

### DIFF
--- a/mimic3/scripts/mimic_program.py
+++ b/mimic3/scripts/mimic_program.py
@@ -8,6 +8,7 @@ Check and save program functionality used by Mimic.
 try:
     import pymel.core as pm
     import maya.mel as mel
+    import numpy as np
 
     MAYA_IS_RUNNING = True
 except ImportError:  # Maya is not running
@@ -937,9 +938,7 @@ def _get_frames_using_sample_rate(animation_settings, postproc_settings):
 def _get_frames_using_keyframes_only(robot, animation_settings):
     """
     Get frames from animation using a robot's keyframes only.
-    Historically Mimic looked for both simultaneous IK and FK keyframes set
-    on a frame to consider it part of the exported keyframes,
-    it was removed since general use tends to favorite IK-only keyframes.
+    This will include ANY keyframe set on either IK tool_CTRL or any of the 6 FK_CTRL handles.
     :param robot:
     :param animation_settings:
     :return:
@@ -947,22 +946,55 @@ def _get_frames_using_keyframes_only(robot, animation_settings):
     # Get relevant animation parameters.
     start_frame = animation_settings['Start Frame']
     end_frame = animation_settings['End Frame']
+
     # Get list of keyframes on robots IK attribute for the given range
     target_ctrl_path = mimic_utils.get_target_ctrl_path(robot)
-    frames = pm.keyframe(
+    ik_keyframes = pm.keyframe(
         target_ctrl_path,
         attribute='ik',
         query=True,
         time='{}:{}'.format(start_frame, end_frame))
-    # Verify that there is also a keyframe set on the FK controls' rotate
-    # attributes. If there's not, we remove it from the list
-    # Note: we only need to check one controller as they are all keyframed
-    # together
-    # fk_test_handle_path = mimic_utils.format_path('{0}|{1}robot_GRP|{1}FK_CTRLS|{1}a1FK_CTRL.rotateY', robot)
-    # frames = [frame for frame in ik_keyframes if pm.keyframe(
-    #    fk_test_handle_path,
-    #    query=True,
-    #    time=frame)]
+    
+    # Get all FK keyframes set per each individual joints
+    fk_1_path = mimic_utils.format_path('{0}|{1}robot_GRP|{1}FK_CTRLS|{1}a1FK_CTRL.rotateY', robot)
+    fk_1_keyframes = pm.keyframe(
+        fk_1_path,
+        query=True,
+        time='{}:{}'.format(start_frame, end_frame))
+    
+    fk_2_path = mimic_utils.format_path('{0}|{1}robot_GRP|{1}FK_CTRLS|{1}a2FK_CTRL.rotateX', robot)
+    fk_2_keyframes = pm.keyframe(
+        fk_2_path,
+        query=True,
+        time='{}:{}'.format(start_frame, end_frame))
+    
+    fk_3_path = mimic_utils.format_path('{0}|{1}robot_GRP|{1}FK_CTRLS|{1}a3FK_CTRL.rotateX', robot)
+    fk_3_keyframes = pm.keyframe(
+        fk_3_path,
+        query=True,
+        time='{}:{}'.format(start_frame, end_frame))
+    
+    fk_4_path = mimic_utils.format_path('{0}|{1}robot_GRP|{1}FK_CTRLS|{1}a4FK_CTRL.rotateY', robot)
+    fk_4_keyframes = pm.keyframe(
+        fk_4_path,
+        query=True,
+        time='{}:{}'.format(start_frame, end_frame))
+    
+    fk_5_path = mimic_utils.format_path('{0}|{1}robot_GRP|{1}FK_CTRLS|{1}a5FK_CTRL.rotateX', robot)
+    fk_5_keyframes = pm.keyframe(
+        fk_5_path,
+        query=True,
+        time='{}:{}'.format(start_frame, end_frame))
+    
+    fk_6_path = mimic_utils.format_path('{0}|{1}robot_GRP|{1}FK_CTRLS|{1}a6FK_CTRL.rotateZ', robot)
+    fk_6_keyframes = pm.keyframe(
+        fk_6_path,
+        query=True,
+        time='{}:{}'.format(start_frame, end_frame))
+
+    # combine all keyframe lists as one unique and deduplicated list
+    frames = list(np.unique(ik_keyframes + fk_1_keyframes + fk_2_keyframes + fk_3_keyframes + fk_4_keyframes + fk_5_keyframes + fk_6_keyframes))
+
     return frames
 
 


### PR DESCRIPTION
option "Sample keyframes only" was looking for IK key frames set also with an FK keyframe on axis 1. This meant that:
- user *must* set both IK and FK keyframes to have these exported
- IK only or FK only animations could not be exported via this method

This PR updates the `_get_frames_using_keyframes_only` function so that it will look for any ik frames set on `tool_CTRL`, but also will look for any FK keyframes set on the timeline on any of the 6 joint handles FK_CTRL. I initially entirely removed the check for FK keyframes but then realized FK-only animations would not be possible, or mix of FK-IK animations would also export only half the path. It nows grab any IK/FK keyframes as lists, then merge and deduplicates the frames before returning it. I also noticed if you would manually keyframe FK handles individually it was only checking for FK keyframes on joint 1, which made any manual FK keyframe set by using `s` shortcut while rotating the handles was missed.

Here showing an animation with beginning as IK, switch to FK with individual joint keyframed, then back to IK, all exported as one ABB RAPID program.

<img width="1193" alt="Screenshot 2023-11-16 at 14 08 44" src="https://github.com/AutodeskRoboticsLab/Mimic/assets/60657807/906e831c-9ef8-4610-8b22-d1547789a27d">

<img width="1193" alt="Screenshot 2023-11-16 at 14 08 55" src="https://github.com/AutodeskRoboticsLab/Mimic/assets/60657807/6b5458d1-3bd0-4e7e-b8a1-e70e160918a8">

```
MODULE MainModule
	! Main routine
	PROC main()
		ConfL\Off;
		SingArea\Wrist;
		! Go to start position
        MoveAbsJ [[0, 0, 0, 0, 0, 0], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]], v100, fine, tool0;
		! Go to programmed positions
		MoveAbsJ [[-42.177, 40.602, 14.054, 131.997, 64.615, -154.538], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]], v100, z0, tool0\WObj:=wobj0;
		MoveAbsJ [[-42.177, 22.114, -18.425, 94.062, 42.308, -95.485], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]], v100, z0, tool0\WObj:=wobj0;
		MoveAbsJ [[-18.480, -4.183, -69.576, 80.857, -57.086, -130.232], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]], v100, z0, tool0\WObj:=wobj0;
		MoveAbsJ [[-13.850, -8.547, -74.557, 78.135, -59.949, -129.683], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]], v100, z0, tool0\WObj:=wobj0;
		MoveAbsJ [[-4.061, -16.844, -79.048, 72.206, -58.476, -125.566], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]], v100, z0, tool0\WObj:=wobj0;
		MoveAbsJ [[25.530, -30.479, -70.789, 52.172, -40.368, -95.543], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]], v100, z0, tool0\WObj:=wobj0;
		MoveAbsJ [[49.227, -8.698, -43.732, 24.398, 1.495, -35.295], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]], v100, z0, tool0\WObj:=wobj0;
		MoveAbsJ [[-2.569, 9.156, -30.350, 13.918, 20.697, -12.838], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]], v100, z0, tool0\WObj:=wobj0;
		MoveAbsJ [[-4.894, 9.555, -30.080, 13.725, 21.076, -12.838], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]], v100, z0, tool0\WObj:=wobj0;
		MoveAbsJ [[44.764, 25.663, -18.422, -97.243, 45.223, 100.228], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]], v100, z0, tool0\WObj:=wobj0;
		! Go to end position
		MoveAbsJ [[0, 0, 0, 0, 0, 0], [9E9, 9E9, 9E9, 9E9, 9E9, 9E9]], v100, fine, tool0;
		Stop;
	ENDPROC
ENDMODULE

```