### PR TITLE
matrix to euler: create new list and round to 0 if very small to prevent atan2 problems

### DIFF
--- a/mimic3/scripts/robotmath/transforms.py
+++ b/mimic3/scripts/robotmath/transforms.py
@@ -156,18 +156,31 @@ def euler_angles_by_matrix(m):
     :param m:
     :return:
     """
-    sb = m[2][0]
+
+    # prevent errors due to Maya returning very small floats and atan2
+    # not playing nice with very small number, round to 0
+    
+    _m = [[0 for x in range(3)] for x in range(3)]
+
+    for i in range(3):
+        for j in range(3):
+            if abs(m[i][j]) < 1E-7:
+                _m[i][j] = 0
+            else:
+                _m[i][j] = m[i][j]
+
+    sb = _m[2][0]
     if 1 - sb * sb < 0:
         cb = 0
     else:
         cb = math.sqrt(1 - sb * sb)
-    ca = m[0][0]
-    sa = -m[1][0]
-    cc = m[2][2]
-    sc = -m[2][1]
-    if abs(m[0][0]) < 1E-7 and abs(m[1][0]) < 1E-7:
-        cc = m[1][1]
-        sc = m[1][2]
+    ca = _m[0][0]
+    sa = -_m[1][0]
+    cc = _m[2][2]
+    sc = -_m[2][1]
+    if abs(_m[0][0]) < 1E-7 and abs(_m[1][0]) < 1E-7:
+        cc = _m[1][1]
+        sc = _m[1][2]
     _a = math.atan2(sa, ca)
     _b = math.atan2(sb, cb)
     _c = math.atan2(sc, cc)
@@ -175,7 +188,6 @@ def euler_angles_by_matrix(m):
     b = _b * -180 / math.pi
     c = _c * -180 / math.pi
     return a, b, c
-
 
 def vector_normalize(v):
     """


### PR DESCRIPTION
While investigating pose rotations while implementing linear export for UR in #44 i stumbled upon very strange euler angles returned by `euler_angles_by_matrix`, traced it to Maya returning not 0 but very small values sometimes and feeding these almost 0 values to atan2 returns wild results.

https://github.com/AutodeskRoboticsLab/Mimic/blob/3c33ea07b29c7e11268fb99078e3afe46c097971/mimic3/scripts/robotmath/transforms.py#L153

I added a step to round down to 0 very small values to prevent that, seems to fix the issue.

Example matrix returned by Mimic/Maya:

```
[-5.715780062744253e-16, 1.0000000000000004, -4.998281860349651e-16]
[-3.8719027983802334e-15, 4.440892098500628e-16, 1.0]
[1.0000000000000004, 2.8899813360850883e-16, 3.6914915568786455e-15]
```

instead of the expected

```
[0,1,0]
[0,0,1]
[1,0,0]
```

which results in `[-98.39746772339547 -90.0 -89.99999999999997]` instead of the correct `[-90,0,-90]`.