### PR TITLE
allow up to 16 external axes from the hardcoded limit of 6

### DIFF
--- a/mimic3/scripts/mimic_external_axes.py
+++ b/mimic3/scripts/mimic_external_axes.py
@@ -622,7 +622,7 @@ def add_external_axis(*args):
                keyable=False,
                attributeType='long',
                minValue=1,
-               maxValue=6,
+               maxValue=16,
                defaultValue=1,
                parent=parent_attribute)
     pm.addAttr(target_CTRL,

--- a/mimic3/scripts/mimic_program.py
+++ b/mimic3/scripts/mimic_program.py
@@ -1163,7 +1163,7 @@ def _sample_frame_get_external_axes(robot_name, frame):
     key_axis_number = 'Axis Number'
     key_position = 'Position'
     # Create an list of Nones for initial external axes
-    external_axes = [None for _ in range(6)]
+    external_axes = [None for _ in range(16)]
     # Get all external axes for this robot
     external_axis_names = mimic_external_axes.get_external_axis_names(robot_name)
     # Get info dict for each of those external axes

--- a/mimic3/scripts/mimic_ui.py
+++ b/mimic3/scripts/mimic_ui.py
@@ -1030,7 +1030,7 @@ def _build_add_external_axis_frame(parent_layout):
                   label='Axis Number:',
                   height=18)
 
-    axis_number_list = [i + 1 for i in range(6)]
+    axis_number_list = [i + 1 for i in range(16)]
     for axis_number in axis_number_list:
         cmds.menuItem(label=axis_number)
 

--- a/mimic3/scripts/postproc/ABB/RAPID/rapid.py
+++ b/mimic3/scripts/postproc/ABB/RAPID/rapid.py
@@ -334,6 +334,7 @@ def _process_motion_command(command, opts):  # Implement in base class!
             if command.external_axes is not None:
                 external_axes = [axis if axis is not None else '9E9'
                                  for axis in command.external_axes]
+                external_axes = external_axes[:6]
                 params = [general_utils.num_to_str(p, include_sign=False, precision=3)
                           for p in external_axes]
                 target_data.extend(params)
@@ -355,6 +356,7 @@ def _process_motion_command(command, opts):  # Implement in base class!
             if command.external_axes is not None:
                 external_axes = [axis if axis is not None else '9E9'
                                  for axis in command.external_axes]
+                external_axes = external_axes[:6]
                 params = [general_utils.num_to_str(p, include_sign=False, precision=3)
                           for p in external_axes]
                 target_data.extend(params)
@@ -379,6 +381,7 @@ def _process_motion_command(command, opts):  # Implement in base class!
             if command.external_axes is not None:
                 external_axes = [axis if axis is not None else '9E9'
                                  for axis in command.external_axes]
+                external_axes = external_axes[:6]
                 params = [general_utils.num_to_str(p, include_sign=False, precision=3)
                           for p in external_axes]
                 target_data.extend(params)

--- a/mimic3/scripts/postproc/KUKA/EntertainTech/entertaintech.py
+++ b/mimic3/scripts/postproc/KUKA/EntertainTech/entertaintech.py
@@ -203,6 +203,7 @@ def _process_records_command(command, opts):
 
     if command.external_axes is not None:
         external_axes = [axis for axis in command.external_axes if axis is not None]
+        external_axes = external_axes[:6]
         formatted_params = [general_utils.num_to_str(axis, include_sign=True, padding=padding)
                             for axis in external_axes]
         params.extend(formatted_params)

--- a/mimic3/scripts/postproc/KUKA/KRL/krl.py
+++ b/mimic3/scripts/postproc/KUKA/KRL/krl.py
@@ -369,6 +369,7 @@ def _process_motion_command(command, opts):
                 if command.external_axes is not None:
                     motion_data_type = E6POS
                     external_axes = [axis if axis is not None else 0 for axis in command.external_axes]
+                    external_axes = external_axes[:6]
                     motion_data.extend(external_axes)
                 else:
                     motion_data_type = POS
@@ -389,6 +390,7 @@ def _process_motion_command(command, opts):
             if command.external_axes is not None:
                 motion_data_type = E6AXIS
                 external_axes = [axis if axis is not None else 0 for axis in command.external_axes]
+                external_axes = external_axes[:6]
                 motion_data.extend(external_axes)
             else:
                 motion_data_type = AXIS

--- a/mimic3/scripts/postproc/Staubli/VAL3/val3.py
+++ b/mimic3/scripts/postproc/Staubli/VAL3/val3.py
@@ -367,6 +367,7 @@ def _process_motion_command(command, opts):
                 if command.external_axes is not None:
                     motion_data_type = E6POS
                     external_axes = [axis if axis is not None else 0 for axis in command.external_axes]
+                    external_axes = external_axes[:6]
                     motion_data.extend(external_axes)
                 else:
                     motion_data_type = POS
@@ -387,6 +388,7 @@ def _process_motion_command(command, opts):
             if command.external_axes is not None:
                 motion_data_type = E6AXIS
                 external_axes = [axis if axis is not None else 0 for axis in command.external_axes]
+                external_axes = external_axes[:6]
                 motion_data.extend(external_axes)
             else:
                 motion_data_type = AXIS

--- a/mimic3/scripts/postproc/postproc.py
+++ b/mimic3/scripts/postproc/postproc.py
@@ -40,6 +40,16 @@ __external_axis_3 = 'external_axis_3'
 __external_axis_4 = 'external_axis_4'
 __external_axis_5 = 'external_axis_5'
 __external_axis_6 = 'external_axis_6'
+__external_axis_7 = 'external_axis_7'
+__external_axis_8 = 'external_axis_8'
+__external_axis_9 = 'external_axis_9'
+__external_axis_10 = 'external_axis_10'
+__external_axis_11 = 'external_axis_11'
+__external_axis_12 = 'external_axis_12'
+__external_axis_13 = 'external_axis_13'
+__external_axis_14 = 'external_axis_14'
+__external_axis_15 = 'external_axis_15'
+__external_axis_16 = 'external_axis_16'
 __configuration_1 = 'configuration_1'
 __configuration_2 = 'configuration_2'
 __configuration_3 = 'configuration_3'
@@ -88,6 +98,16 @@ ExternalAxes = namedtuple(
         __external_axis_4,  # float
         __external_axis_5,  # float
         __external_axis_6,  # float
+        __external_axis_7,  # float
+        __external_axis_8,  # float
+        __external_axis_9,  # float
+        __external_axis_10,  # float
+        __external_axis_11,  # float
+        __external_axis_12,  # float
+        __external_axis_13,  # float
+        __external_axis_14,  # float
+        __external_axis_15,  # float
+        __external_axis_16  # float
     ]
 )
 


### PR DESCRIPTION
our workflow does not use mFIZ but external axes to program FIZ, plus a track and couple model moving motors means we already max out the hard limit on external axes which is currently 6. We need additional external axes for forthcoming projects so looked into extending the hardcoded  max Axis Number.

This pr allows up to 16 external axes to be created and rigged in the UI, but as some robots have a hardware limit of 6 external axes (Kuka KRL, ABB Rapid..), also updates these post-processors to only use the first 6 external axes. The CSV/TSV post processor will export any of the maximum 16 rigged external axes.

note: I noticed that if rigging a single axis with Axis Number set to anything other than 1, the post-processed file wont be positionally correct, eg rigging a single axis as n°3 wont export it as E3, unless 2 other axes are rigged as 1 and 2, it will end up as E1. Easy workaround to add first 2 unused axes but might be worth patching later on.